### PR TITLE
yaml

### DIFF
--- a/Sources/StringsLintFramework/Parsers/Configuration/StringIgnoreYamlParser.swift
+++ b/Sources/StringsLintFramework/Parsers/Configuration/StringIgnoreYamlParser.swift
@@ -38,6 +38,7 @@ struct StringIgnoreYamlParser {
 Please specify a DRE for these strings in the following format:
 directly_responsible_engineer_name:
   John Doe
+
 """
         )
       )

--- a/Sources/StringsLintFramework/Parsers/Configuration/StringIgnoreYamlParser.swift
+++ b/Sources/StringsLintFramework/Parsers/Configuration/StringIgnoreYamlParser.swift
@@ -1,0 +1,71 @@
+//
+//  StringIgnoreYamlParser.swift
+//  
+//
+//  Created by Haocen Jiang on 2022-10-19.
+//
+
+import Foundation
+
+struct StringIgnoreYamlParser {
+  var severity: ViolationSeverity
+
+  init(severity: ViolationSeverity = .warning) {
+    self.severity = severity
+  }
+
+  struct IgnoredStringsKey {
+    let key: String
+    let location: Location
+  }
+
+  func supports(file: File) -> Bool {
+    file.name.hasSuffix(".ignore.yml")
+  }
+
+  func parseFile(file: File) throws -> ([Violation], [IgnoredStringsKey]) {
+    let data = try YamlParser.parse(file.content)
+    var _fileViolations = [Violation]()
+    var _wipStrings = Set<String>()
+
+    if data["directly_responsible_engineer_name"] == nil {
+      _fileViolations.append(
+        Violation(
+          ruleDescription: UnusedSwiftGenRule.description,
+          severity: severity,
+          location: Location(file: file),
+          reason: """
+Please specify a DRE for these strings in the following format:
+directly_responsible_engineer_name:
+  John Doe
+"""
+        )
+      )
+    }
+
+    if let wipStrings = data["work_in_progress"] as? [String] {
+      _wipStrings = Set(wipStrings)
+    }
+
+    let lineNumberMap = [String: Location](
+      uniqueKeysWithValues: file.lines.enumerated().compactMap { line -> (String, Location)? in
+        let maybeKey = line.element.trimmingCharacters(in: CharacterSet.whitespaces.union(CharacterSet(["-"])))
+        if _wipStrings.contains(maybeKey) {
+          return (maybeKey, Location(file: file, line: line.offset+1))
+        }
+
+        return nil
+      }
+    )
+
+    let ignoredStringsKeys = _wipStrings.compactMap { (string) -> IgnoredStringsKey? in
+      guard let location = lineNumberMap[string] else { return nil }
+      return IgnoredStringsKey(key: string, location: location)
+    }
+
+    return (
+      _fileViolations,
+      ignoredStringsKeys
+    )
+  }
+}

--- a/Sources/StringsLintFramework/Parsers/Configuration/StringIgnoreYamlParser.swift
+++ b/Sources/StringsLintFramework/Parsers/Configuration/StringIgnoreYamlParser.swift
@@ -19,29 +19,21 @@ struct StringIgnoreYamlParser {
     let location: Location
   }
 
+  enum IgnoreYamlFileVioationType {
+    case noDRE(Location)
+  }
+
   func supports(file: File) -> Bool {
     file.name.hasSuffix(".ignore.yml")
   }
 
-  func parseFile(file: File) throws -> ([Violation], [IgnoredStringsKey]) {
+  func parseFile(file: File) throws -> ([IgnoreYamlFileVioationType], [IgnoredStringsKey]) {
     let data = try YamlParser.parse(file.content)
-    var _fileViolations = [Violation]()
+    var _fileViolations = [IgnoreYamlFileVioationType]()
     var _wipStrings = Set<String>()
 
     if data["directly_responsible_engineer_name"] == nil {
-      _fileViolations.append(
-        Violation(
-          ruleDescription: UnusedSwiftGenRule.description,
-          severity: severity,
-          location: Location(file: file),
-          reason: """
-Please specify a DRE for these strings in the following format:
-directly_responsible_engineer_name:
-  John Doe
-
-"""
-        )
-      )
+      _fileViolations.append(.noDRE(Location(file: file)))
     }
 
     if let wipStrings = data["work_in_progress"] as? [String] {

--- a/Sources/StringsLintFramework/Rules/Configuration/UnusedSwiftGenRuleConfiguration.swift
+++ b/Sources/StringsLintFramework/Rules/Configuration/UnusedSwiftGenRuleConfiguration.swift
@@ -17,6 +17,7 @@ public struct UnusedSwiftGenRuleConfiguration: RuleConfiguration {
   public var severity: ViolationSeverity = .warning
   public var workInProgressStrings = [String]()
   public var ignored = [String]()
+  public var helpLink: String?
 
   public mutating func apply(_ configuration: Any) throws {
 
@@ -27,5 +28,6 @@ public struct UnusedSwiftGenRuleConfiguration: RuleConfiguration {
     self.severity = ViolationSeverity(rawValue: configuration["severity"] as! String) ?? self.severity
     self.ignored += defaultStringArray(configuration["ignored"])
     self.workInProgressStrings += defaultStringArray(configuration["work_in_progress"])
+    self.helpLink = configuration["help_link"] as? String
   }
 }

--- a/Sources/StringsLintFramework/Rules/Lint/UnusedSwiftGenRule.swift
+++ b/Sources/StringsLintFramework/Rules/Lint/UnusedSwiftGenRule.swift
@@ -19,6 +19,14 @@ public class UnusedSwiftGenRule: LintRule {
   private let declareParser: LocalizableParser
   private let usageParser: LocalizableParser
   private let ignoreYamlParser: StringIgnoreYamlParser
+  private let helpLink: String?
+  private var helpLinkDescription: String {
+    if let helpLink = helpLink {
+      return " For more information, please see: \(helpLink)"
+    } else {
+      return ""
+    }
+  }
 
   public static var description = RuleDescription(
     identifier: "unused_swiftgen_strings",
@@ -32,7 +40,8 @@ public class UnusedSwiftGenRule: LintRule {
               usageParser: ComposedParser(parsers: [ SwiftL10nParser() ]),
               ignoredStrings: config.ignored,
               wipStrings: config.workInProgressStrings,
-              severity: config.severity)
+              severity: config.severity,
+              helpLink: config.helpLink)
   }
 
   public required convenience init(configuration: Any) throws {
@@ -51,7 +60,8 @@ public class UnusedSwiftGenRule: LintRule {
       ]),
       ignoredStrings: config.ignored,
       wipStrings: config.workInProgressStrings,
-      severity: config.severity
+      severity: config.severity,
+      helpLink: config.helpLink
     )
   }
 
@@ -59,13 +69,15 @@ public class UnusedSwiftGenRule: LintRule {
               usageParser: LocalizableParser,
               ignoredStrings: [String],
               wipStrings: [String],
-              severity: ViolationSeverity) {
+              severity: ViolationSeverity,
+              helpLink: String?) {
     self.declareParser = declareParser
     self.usageParser = usageParser
     self.ignoredStrings = Set(ignoredStrings.map { $0.toL10nGenerated() })
     self.wipStrings = Set(wipStrings.map { $0.toL10nGenerated() })
     self.ignoreYamlParser = .init(severity: severity)
     self.severity = severity
+    self.helpLink = helpLink
   }
 
   public func processFile(_ file: File) {
@@ -109,7 +121,7 @@ public class UnusedSwiftGenRule: LintRule {
           ruleDescription: UnusedSwiftGenRule.description,
           severity: severity,
           location: string.location,
-          reason: "This string is marked as WIP in .stringslint.yml, please remove this string from the WIP list."
+          reason: "This string is marked as WIP in .stringslint.yml, please remove this string from the WIP list.\(helpLinkDescription)"
         )
       }
 
@@ -118,7 +130,7 @@ public class UnusedSwiftGenRule: LintRule {
           ruleDescription: UnusedSwiftGenRule.description,
           severity: severity,
           location: ignoreKey.location,
-          reason: "This string is marked as WIP here but is referenced at \"\(string.location)\", please remove this string."
+          reason: "This string is marked as WIP here but is referenced at \"\(string.location)\", please remove this string.\(helpLinkDescription)"
         )
       }
       return nil
@@ -176,7 +188,7 @@ public class UnusedSwiftGenRule: LintRule {
       ruleDescription: UnusedSwiftGenRule.description,
       severity: self.severity,
       location: location,
-      reason: "Localized string \"\(comment)\" is unused. If you intend to use this string in a later PR, please add it to the \"work_in_progress\" list in .stringslint.yml"
+      reason: "Localized string \"\(comment)\" is unused. If you intend to use this string in a later PR, please add it to the \"work_in_progress\" list in .stringslint.yml or create a new \".ignore.yml\" file.\(helpLinkDescription)"
     )
   }
 }

--- a/Sources/StringsLintFramework/Rules/Lint/UnusedSwiftGenRule.swift
+++ b/Sources/StringsLintFramework/Rules/Lint/UnusedSwiftGenRule.swift
@@ -140,10 +140,23 @@ public class UnusedSwiftGenRule: LintRule {
   private func parseIgnoreYamlFile(_ file: File){
     do {
       let (violations, keys) = try ignoreYamlParser.parseFile(file: file)
-      yamlFileViolations += violations
+      yamlFileViolations += violations.map(parseYamlViolation)
       ignoreKeys += keys
     } catch {
     }
+  }
+
+  private func parseYamlViolation(violation: StringIgnoreYamlParser.IgnoreYamlFileVioationType) -> Violation {
+    switch violation {
+    case .noDRE(let location):
+      return Violation(
+        ruleDescription: UnusedSwiftGenRule.description,
+        severity: severity,
+        location: location,
+        reason: "Please specify a DRE for these strings.\(helpLinkDescription)"
+      )
+    }
+
   }
 
   private func processDeclarationFile(_ file: File) -> [LocalizedString] {

--- a/Sources/stringslint/Extensions/FileManager+StringsLint.swift
+++ b/Sources/stringslint/Extensions/FileManager+StringsLint.swift
@@ -19,7 +19,7 @@ extension FileManager: LintableFileManager {
         let absolutePath = path.bridge()
             .absolutePathRepresentation(rootDirectory: rootPath).bridge()
             .standardizingPath
-        
+
         // if path is a file, it won't be returned in `enumerator(atPath:)`
         if absolutePath.isFile {
             return [absolutePath]

--- a/Sources/stringslint/Helpers/Linter.swift
+++ b/Sources/stringslint/Helpers/Linter.swift
@@ -66,5 +66,5 @@ func supportedFilesExtentions() -> Set<String> {
     // based on all the parsers implemented in the library
     let parsers: [LocalizableParser] = [ StringsParser(), StringsdictParser(), ObjcParser(), SwiftParser(), XibParser() ]
     let extensions = parsers.flatMap { $0.supportedFileExtentions }
-    return Set(extensions.map { ".\($0)" })
+    return Set(extensions.map { ".\($0)" }).union(Set([".yml"]))
 }

--- a/Tests/StringsLintFrameworkTests/Rules/UnusedSwiftGenRuleTests.swift
+++ b/Tests/StringsLintFrameworkTests/Rules/UnusedSwiftGenRuleTests.swift
@@ -49,6 +49,34 @@ let myVar = abc
     XCTAssertEqual(rule.violations.count, 1)
   }
 
+  func testHelpLink() throws {
+
+    let stringsFile = File(
+      name: "Localizable.strings",
+      content: """
+          \"abc\" = \"A B C\";
+"""
+    )
+
+    let usageFile = File(name: "hi.swift", content: """
+let myVar = abc
+""")
+
+    let stringsLintConfig = [
+      "unused_swiftgen_strings": [
+        "severity": "warning",
+        "help_link": "www.faire.com"
+      ]
+    ]
+
+    let rule = try UnusedSwiftGenRule(configuration: stringsLintConfig)
+
+    rule.processFile(stringsFile)
+    rule.processFile(usageFile)
+
+    XCTAssertEqual(rule.violations[0].description, "<nopath>:1: warning: Unused SwiftGen String Violation: Localized string \"abc\" is unused. If you intend to use this string in a later PR, please add it to the \"work_in_progress\" list in .stringslint.yml or create a new \".ignore.yml\" file. For more information, please see: www.faire.com (unused_swiftgen_strings)")
+  }
+
   func testStringWithNestedUsage() {
 
     let stringsFile = File(
@@ -239,7 +267,8 @@ work_in_progress:
     XCTAssertEqual(rule.violations[0].description, """
 <nopath>:1: error: Unused SwiftGen String Violation: Please specify a DRE for these strings in the following format:
 directly_responsible_engineer_name:
-  John Doe (unused_swiftgen_strings)
+  John Doe
+ (unused_swiftgen_strings)
 """)
 
   }


### PR DESCRIPTION
- Make sure WIP strings are not used in the codebase
- Adds an alternative way to configure wip strings (through xxx.ignore.yml)
- Adds help link