### PR TITLE
Updates regex

### DIFF
--- a/Sources/StringsLintFramework/Parsers/SwiftL10nParser.swift
+++ b/Sources/StringsLintFramework/Parsers/SwiftL10nParser.swift
@@ -45,7 +45,7 @@ public struct SwiftL10nParser: LocalizableParser {
 
 private extension SwiftL10nParser {
   enum Constants {
-    static let L10nPattern = #"L10n((\n\s*)?\.[a-zA-Z0-9.]+)+"#
+    static let L10nPattern = #"L10n((\s*\n\s*)?\.[A-Z][a-zA-Z0-9]*)*(\s*\n\s*)?(\.[a-z][a-zA-Z0-9]*)"#
   }
 
   /// Maps the match order to file number
@@ -53,7 +53,7 @@ private extension SwiftL10nParser {
     var counter = 0
     var map = [Int: Int]()
     for (idx, line) in file.lines.enumerated() {
-      let regex = try! NSRegularExpression(pattern: #"L10n\."#)
+      let regex = try! NSRegularExpression(pattern: #"L10n"#)
       for _ in regex.matches(in: line, range: NSRange(line.startIndex..., in: line)) {
         map[counter] = idx+1
         counter += 1

--- a/Tests/StringsLintFrameworkTests/Rules/UnusedSwiftGenRuleTests.swift
+++ b/Tests/StringsLintFrameworkTests/Rules/UnusedSwiftGenRuleTests.swift
@@ -49,6 +49,48 @@ let myVar = abc
     XCTAssertEqual(rule.violations.count, 1)
   }
 
+  func testStringWithUsage_stringOperation() {
+
+    let stringsFile = File(
+      name: "Localizable.strings",
+      content: """
+          \"abc\" = \"A B C\";
+"""
+    )
+
+    let usageFile = File(name: "hi.swift", content: """
+let myVar = L10n.abc.underlined
+""")
+
+    let rule = UnusedSwiftGenRule()
+    rule.processFile(stringsFile)
+    rule.processFile(usageFile)
+
+    XCTAssertEqual(rule.violations.count, 0)
+  }
+
+  func testStringWithUsage_multiline() {
+
+    let stringsFile = File(
+      name: "Localizable.strings",
+      content: """
+          \"abc.def\" = \"A B C\";
+"""
+    )
+
+    let usageFile = File(name: "hi.swift", content: """
+let myVar = L10n
+  .Abc
+  .def
+""")
+
+    let rule = UnusedSwiftGenRule()
+    rule.processFile(stringsFile)
+    rule.processFile(usageFile)
+
+    XCTAssertEqual(rule.violations.count, 0)
+  }
+
   func testStringWithNoUsage_multipleStringsFiles() {
 
     let stringsFile1 = File(


### PR DESCRIPTION
It's possible to perform other operations on the L10n string, e.x. we have usage like `L10n.dismiss.underlined` and the current parser will think we are trying to use the key `DISMISS.UNDERLINED`. Update is to stop parsing at the first lowercased word.